### PR TITLE
Edits to move all outputs to the output directory + HTML bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,8 @@
 *~
 
 output/*
-ofBook.html
-ofBook.tex
-ofBook.pdf
 /images
 /chapters/*/chapter_modified_for_print.md
-/scripts/ofBook.*
 
 web/_site
 *.orig

--- a/scripts/createPDFBook.py
+++ b/scripts/createPDFBook.py
@@ -8,16 +8,19 @@
 		- ofBook
 			- scripts
 				- createPDFBook.py
-				- ofBookTemplate.tex
+				- ofBookTemplate.tex 
 			- chapters
 				- CHAPTER_NAME
 					- chapter.md
 					- images/
-				- order.txt 
-
-	where order.txt is an ordered list of the chapters of ofBook
-
-	The final PDF is saved to ofBook/ofBook.pdf 
+				- order.txt (order list of chapters in ofBook)
+				
+	After running, the pdf and tex of ofBook will be added to output/ like this:
+		- ofBook
+			- ...
+			- output
+				- ofBook.pdf
+				- ofBook.tex	
 
 	Dependencies: 
 		Pandoc
@@ -28,7 +31,10 @@ import re
 import subprocess
 
 # Output path
-pdfBookPath = os.path.join("..", "ofBook.pdf") 
+outputPath = os.path.join("..", "output")
+if not os.path.exists(outputPath): os.makedirs(outputPath)
+pdfBookPath = os.path.join(outputPath, "ofBook.pdf") 
+texBookPath = os.path.join(outputPath, "ofBook.tex") 
 
 # Load each chapter from order.txt, do any pre-processing necessary and save the
 # final version as /../chapters/CHAPTER_NAME/chapterModified.md
@@ -80,7 +86,6 @@ for flag in generalOptions+latexOptions:
 # For debugging purposes, it's a good idea to generate the .tex.  Errors
 # printed out through pandoc aren't as useful as those printed
 # directly from trying to build a PDF in TeXworks.
-texBookPath = "ofBook.tex"
 texOutputOptions = ["--output={0}".format(texBookPath)]
 texPandocCommand = ["pandoc"] + texOutputOptions + inputOptions + generalOptions + latexOptions
 returnCode = subprocess.call(texPandocCommand)

--- a/scripts/createWebBook.py
+++ b/scripts/createWebBook.py
@@ -16,17 +16,25 @@
 					- chapter.md
 					- images
 				- order.txt 
-			- output
-				- chapters
+			- static
+				- javascript
 				- style
 					- fonts
-					- style.css
 
-	After running, the chapters will be added to output/chapters like this:
-		- chapters
-			- CHAPTER_X
-				- images
-			- CHAPTER_X.html
+	After running, the website will be added to output/webBook like this:
+		- ofBook
+			- ...
+			- output
+				- webBook
+					- chapters
+						- CHAPTER_NAME.html
+					- images
+						- CHAPTER_NAME
+							- images go here
+					- javascript
+					- style
+						- fonts
+					- toc.html (Table of Contents)			
 
 	The reason for this structure is that, for firefox, the fonts directory must be located
 	on the same domain as CHAPTER_X.html (i.e. it must be in /chapters or a subdirectory of /chapters)
@@ -59,15 +67,23 @@ def wrap(to_wrap, wrap_in):
     wrap_in.append(contents)
 
 
-chapters = open("../chapters/order.txt").read().splitlines()
+# Get the order of the chapters
+chapterOrderPath = os.path.join("..", "chapters", "order.txt")
+chapters = open(chapterOrderPath).read().splitlines()
 
+# Create the output directories for the webBook
+webBookPath = os.path.join("..", "output", "webBook")
+webBookChaptersPath = os.path.join(webBookPath, "chapters")
+if not os.path.exists(webBookPath): os.makedirs(webBookPath)
+if not os.path.exists(webBookChaptersPath): os.makedirs(webBookChaptersPath)
 
-if not os.path.exists("../output/chapters"):
-    os.makedirs("../output/chapters")
-
-
-copytree("../static/style", "../output/style")
-copytree("../static/javascript", "../output/javascript")
+# Copy static directories
+staticStylePath = os.path.join("..", "static", "style")
+webBookStylePath = os.path.join(webBookPath, "style")
+staticJSPath = os.path.join("..", "static", "javascript")
+webBookJSPath = os.path.join(webBookPath, "javascript")
+copytree(staticStylePath, webBookStylePath)
+copytree(staticJSPath, webBookJSPath)
 
 
 chapterTags = [];
@@ -77,8 +93,8 @@ for chapter in chapters:
 	sourceChapterPath = os.path.join(sourceDirectoryPath, "chapter.md")
 	sourceImagesPath = os.path.join(sourceDirectoryPath, "images")
 
-	destDirectoryPath = os.path.join("..", "output", "images", chapter)
-	destChapterPath = os.path.join("..", "output", "chapters", chapter+".html")
+	destDirectoryPath = os.path.join(webBookPath, "images", chapter)
+	destChapterPath = os.path.join(webBookPath, "chapters", chapter+".html")
 	destImagesPath = os.path.join(destDirectoryPath, "images")
 
 	internalImagesPath = os.path.join("..", "images", chapter)
@@ -167,7 +183,7 @@ for c in chapterTags:
 	ul = Tag(soup, None, "ul")
 	li = Tag(soup, None, "li")
 	a = Tag(soup, None, "a");
-	a['href'] = c['path'];
+	a['href'] = "chapters/" + c['path'] + ".html"
 	a.string = c['title']
 	li.append(a)
 	ul.append(li)
@@ -181,7 +197,8 @@ for c in chapterTags:
 			liInner = Tag(soup, None, "li")
 			ulInner.append(liInner)
 			a = Tag(soup, None, "a")
-			a['href'] = "chapters/" + c['path'] + ".html#" + tag
+			tagNoSpaces = tag.replace(" ", "")
+			a['href'] = "chapters/" + c['path'] + ".html#" + tagNoSpaces
 			a['target'] = "_top"
 			a.string = tag
 			liInner.append(a);
@@ -190,7 +207,8 @@ for c in chapterTags:
 	html.append(ul);
 
 htmlOut = soup.prettify("utf-8")
-with open("../output/toc.html", "wb") as file:
+tocPath = os.path.join(webBookPath, "toc.html")
+with open(tocPath, "wb") as file:
     file.write(htmlOut)
 
 # <ul>


### PR DESCRIPTION
The webBook is now in `output/webBook`.  The pdf and tex files are now in `output/`.  Comments were updated to reflect these changes.

HTML fixes in TOC:
- Links to top levels of chapter (i.e. intro.html) were not complete paths
- Tags added to chapter URLs to allow view to jump to a specific header weren't working.  There were spaces in the tags added to the URL - removed them.
