### PR TITLE
fix data vis chapter typo #2

### DIFF
--- a/chapters/data_vis/chapter.md
+++ b/chapters/data_vis/chapter.md
@@ -273,9 +273,6 @@ void testApp::setup(){
         data.ala = ofToFloat(split[3]);
         dataPoints.push_back(data);
     }
-
- // let's round up to the next "10" on the max value
-    maxValue = ceil(maxValue / 10) * 10;
     
     
     // let's find the min and max years, and the max value for the data.


### PR DESCRIPTION
```
    // let's round up to the next "10" on the max value
    maxValue = ceil(maxValue / 10) * 10;
```
this block was defined twice: before and after (lines 299-300 now)  looking for min/max values, the first is not needed.