### PR TITLE
added a gulpfile to help work on CSS with reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,8 @@ Since [git](http://git-scm.com/) is at the heart of the management of this endea
 [openFrameworks Book discussion](http://dev.openframeworks.cc/listinfo.cgi/ofbook-openframeworks.cc).
 
 Older Book discussions can be checked at [ofBook Archives](http://dev.openframeworks.cc/private.cgi/ofbook-openframeworks.cc/)
+
+# gulp
+
+In addition to the python routines to build the book, there is also an optional gulp file for use in style development.  It requires gulp, browser-sync and gulp sass and can be used primarily to see changes to CSS reflect live on the static pages.  You have to run the python createWebBook script first. 
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,25 @@
+var gulp        = require('gulp');
+var browserSync = require('browser-sync').create();
+var sass        = require('gulp-sass');
+
+// Static Server + watching scss/html files
+gulp.task('serve', ['sass'], function() {
+
+    browserSync.init({
+        server: "./output/webBook"
+    });
+
+    gulp.watch("static/style/*.scss", ['sass']);
+    //gulp.watch("output/webBook/chapter/*.html").on('change', browserSync.reload);
+    gulp.watch("output/webBook/**").on('change', browserSync.reload);
+});
+
+// Compile sass into CSS & auto-inject into browsers
+gulp.task('sass', function() {
+    return gulp.src("static/style/style.scss")
+        .pipe(sass())
+        .pipe(gulp.dest("output/webBook/style/"))
+        .pipe(browserSync.stream());
+});
+
+gulp.task('default', ['serve']);


### PR DESCRIPTION
this adds a simple gulpfile to work on css with reload (while the sass is getting compiled as part of python script to make the web book, gulp / browser-sync is much faster for testing changes on style).  Requires gulp, browser sync, gulp-sass   (ie, npm install browser-sync gulp-sass)