### PR TITLE
Fix markdown to view on github

### DIFF
--- a/chapters/foreword/chapter.md
+++ b/chapters/foreword/chapter.md
@@ -1,4 +1,4 @@
-#Foreword
+# Foreword
 
 *by [Zach Lieberman](http://thesystemis.com)*
 
@@ -24,7 +24,7 @@ In recent years, we've tried to help grow and expand the community -- folks like
 More than anything, we've tried as hard as we can to create a friendly atmosphere around programming, which can be an unfriendly activity and in some ways isolating.  We preach the idea of art-making as a laboratory, as R&D (Research & Development) for humanity, and oF is one attempt to make a large lab where we can grow and share experiments together.   There's been a big movement for DIY  (Do it Yourself) culture these days, things like Make Magazine and Instructables promoting a culture of sharing through making.  We are big fans of DIWO (Do it With Others) and try to do that as much as we can online and offline.  Somehow, luckily, we've attracted some of the most amazing, helpful, warm-hearted, lovely people to come be a part of this, and if you're not already, we'd like to say **welcome**.
 
 
-## about this book
+## About This Book
 
 This book, much in the spirit of openFrameworks, is a community driven affair and it's **very much a work in progress**.   It was a suggestion on the openFrameworks developers mailing list which kicked this off and for a the past months we've been hacking away on it.
 
@@ -38,7 +38,7 @@ A couple of notes,
 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/deed.en_US"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" /></a>
 
 
-## credits
+## Credits
 
 Countless thanks to Rachel Uwa for organizing this project, Tega Brain for helping edit it, Ishac Bertran and Andy Clymer for directing the design, and Arturo Castro, Christoph Buchner and Michael Hadley for developing the codebase for generating the book.   In addition, the following authors and editors have contributed to this book:  Rui Pereira, Arturo Castro, Brannon Dorsey, Zach Lieberman, Kayla Lewis, Josh Nimoy, Phoenix Perry, Jane Friedhoff, Caitlin Morris, Pierre Proske, Golan Levin, Blair Neal, Michael Hadley, Abraham Avnisan, Christopher Baker, Lukasz Karluk, Omer Shapira, Mimi Son & Elliot Woods (Kimchi and Chips), Eva Schindling, Pierre Thirion, Joel Gethin Lewis, Roy Macdonald, Adam Carlucci, Christoph Buchner, tpltnt as well as countless others who have given feedback, submitted pull requests, offered advice, etc.
 


### PR DESCRIPTION
TL;DR

Headings now need a space after the # to be parsed correctly.

See:

https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown
https://githubengineering.com/a-formal-spec-for-github-markdown/