### PR TITLE
Clean up code for animation/code/17_noise

### DIFF
--- a/chapters/animation/code/17_noise/src/ofApp.cpp
+++ b/chapters/animation/code/17_noise/src/ofApp.cpp
@@ -5,32 +5,44 @@ void ofApp::setup(){
 	ofBackground(255,255,255);
 	//ofSetFrameRate(5);
 	ofSetVerticalSync(true);
-	colorScheme.loadImage("sunset.png");
+	colorScheme.load("sunset.png");
 }
 
 //--------------------------------------------------------------
 void ofApp::draw(){
 	ofEnableAlphaBlending();
-	ofSetColor(255,255,255, 100);
+	ofSetColor(255, 255, 255, 100);
 	ofSeedRandom(0); // always pick the same random numbers.
 
-	for (int i = 0; i < mouseX*3; i++){
-		float x = ofNoise(ofGetElapsedTimef()*0.2, i*0.3)*ofGetWidth();
-		float y = ofNoise(-ofGetElapsedTimef()*0.2, i*0.3)*ofGetHeight();
-		ofColor col = getColorForPixel( ofMap(x,0,ofGetWidth(), 0, colorScheme.width),
-						ofMap(y,0,ofGetHeight(), 0, colorScheme.height));
-		col.a = 85;	// set some alpha. 
-		ofSetColor(col);
-		ofDrawCircle(x,y,ofRandom(4,40));
+  float currentTime = ofGetElapsedTimef();
+
+	for (int i = 0; i < mouseX * 3; i++){
+    float screenWidth = ofGetWidth();
+    float screenHeight = ofGetHeight();
+
+    float xNoise = ofNoise(currentTime * 0.2, i * 0.3);
+    float yNoise = ofNoise(-currentTime * 0.2, i * 0.3);
+
+    float x = xNoise * screenWidth;
+    float y = yNoise * screenHeight;
+
+    ofColor color = getColorForPixel(
+      ofMap(x, 0, screenWidth, 0, colorScheme.getWidth()),
+      ofMap(x, 0, screenHeight, 0, colorScheme.getHeight()),
+      colorScheme
+    );
+
+    color.a = 85; // set some alpha.
+
+    ofSetColor(color);
+    ofDrawCircle(x, y, ofRandom(4, 40));
 	}
 }
 
 //--------------------------------------------------------------
-ofColor ofApp::getColorForPixel(int x, int y){
-	if (x < 0) x = 0;
-	if (y < 0) y = 0;
-	if (x >= colorScheme.width) x = colorScheme.width-1;
-	if (y >= colorScheme.height) y = colorScheme.height-1;
+ofColor ofApp::getColorForPixel(int x, int y, const ofImage& img) {
+  x = ofClamp(x, 0, colorScheme.getWidth() - 1);
+  y = ofClamp(y, 0, colorScheme.getHeight() - 1);
 
 	return colorScheme.getColor(x,y);
 }

--- a/chapters/animation/code/17_noise/src/ofApp.h
+++ b/chapters/animation/code/17_noise/src/ofApp.h
@@ -10,5 +10,5 @@ class ofApp : public ofBaseApp{
 
 		float position;
 		ofImage colorScheme;
-		ofColor getColorForPixel(int x, int y);
+		ofColor getColorForPixel(int x, int y, const ofImage& img);
 };


### PR DESCRIPTION
I ran into a few issues while following along with the code in the `animations/code/17_noise` project.
It's a wonderful demo -- hopefully these changes help anyone digging into it in the future.

- Use `ofImage.load` instead of the deprecated `ofImage.loadImage`.

- Use getters to access the image's `width` and `height` properties (Otherwise, the compiler throws an error for trying to access a private property).

- Utlize `ofClamp` within the `getColorForPixel` helper.

- Slightly tweak the code within the `draw` loop to be more explicit about what each value represents.