### PR TITLE
Fixes Compile Error

### DIFF
--- a/chapters/intro_to_graphics/code/2_ii_b_Polyline_Brushes/src/ofApp.cpp
+++ b/chapters/intro_to_graphics/code/2_ii_b_Polyline_Brushes/src/ofApp.cpp
@@ -61,7 +61,7 @@ void ofApp::draw(){
         // original polyline drawing on line 57, if you like.
 
         // Drawing evenly spaced points along the polyline
-//        vector<ofVec3f> vertices = polyline.getVertices();  // If you haven't seen a vector < >, before
+//        vector<glm::vec3> vertices = polyline.getVertices();  // If you haven't seen a vector < >, before
 //        for (int p=0; p<100; p+=10) {
 //            ofVec3f point = polyline.getPointAtPercent(p/100.0);  // Returns a point at a percentage along the polyline
 //            ofDrawCircle(point, 5);


### PR DESCRIPTION
`getVerticies()` returns `vector<glm::vec3>`. On Windows `vector<ofVec3f>` results in a compile error.

Note that `verticies` is never actually used, but I think that the intent of this line is to show the reader how to declare a vector. If that's the case, then it probably makes more sense to fix the vector declaration rather then remove the line.